### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ ./srun config
 如果已经[安装并配置GO环境](https://golang.google.cn/doc/install), 执行如下命令即可
 
 ```bash
-$ go get -u -v github.com/vouv/srun/cmd/srun
+$ go install github.com/vouv/srun/cmd/srun@latest
 $ $GOPATH/bin/srun config
 ```
 


### PR DESCRIPTION
`go get` → `go install`.

```
 'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```